### PR TITLE
Support Azure OpenAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ By default, it is set to use the `gpt-3.5-turbo` model. If you want to use GPT-4
 call ai_review#config({ 'chat_gpt': { 'model': 'gpt-4' } })
 ```
 
+If you want to use with Azure OpenAI Service, you'll need to include an endpoint and an api-version:
+
+```vim
+call ai_review#config({ 'chat_gpt': { 'model': 'gpt-4', 'azure': { 'use': v:true, 'url': 'https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME', 'api_version': '2023-07-01-preview' } } })
+```
+
 If you want to use nui.nvim instead of ddu, please set as follows:
 
 ```vim

--- a/autoload/ai_review.vim
+++ b/autoload/ai_review.vim
@@ -3,6 +3,9 @@ let g:ai_review#_config = {
       \ 'log_dir': expand('~/.cache/vim/ai-review'),
       \ 'chat_gpt': {
       \   'model': 'gpt-3.5-turbo',
+      \   'azure': {
+      \      'use': v:false,
+      \   },
       \   'requests': [{
       \     'title': 'Find bugs',
       \     'request': function('ai_review#open_ai#request#find_bugs'),

--- a/denops/ai-review/openai/client.ts
+++ b/denops/ai-review/openai/client.ts
@@ -1,60 +1,60 @@
-import { OPENAI_MAX_TOKENS } from "../constant.ts";
+import { OPENAI_MAX_TOKENS } from "../constant.ts"
 import {
   ChatCompletionRequestMessage,
   Configuration,
   OpenAIApi,
   OpenAIStream,
-} from "../deps/ai.ts";
-import { azureConfigSelector, modelSelector } from "../store/config.ts";
+} from "../deps/ai.ts"
+import { azureConfigSelector, modelSelector } from "../store/config.ts"
 
-const ORGANIZATION = Deno.env.get("OPENAI_ORGANIZATION") ?? "";
-const API_KEY = Deno.env.get("OPENAI_API_KEY");
+const ORGANIZATION = Deno.env.get("OPENAI_ORGANIZATION") ?? ""
+const API_KEY = Deno.env.get("OPENAI_API_KEY")
 
 type Client = {
-  completions: typeof completions;
-};
+  completions: typeof completions
+}
 
 async function completions({
   messages,
 }: {
-  messages: Array<ChatCompletionRequestMessage>;
+  messages: Array<ChatCompletionRequestMessage>
 }): Promise<ReadableStream<string>> {
-  const azureConfig = azureConfigSelector();
+  const azureConfig = azureConfigSelector()
   const config: Configuration = azureConfig.use
     ? new Configuration({
-        apiKey: API_KEY,
-        baseOptions: {
-          headers: {
-            "api-key": API_KEY,
-          },
+      apiKey: API_KEY,
+      baseOptions: {
+        headers: {
+          "api-key": API_KEY,
         },
-        basePath: azureConfig.url,
-        defaultQueryParams: new URLSearchParams({
-          "api-version": azureConfig.api_version,
-        }),
-      })
+      },
+      basePath: azureConfig.url,
+      defaultQueryParams: new URLSearchParams({
+        "api-version": azureConfig.api_version,
+      }),
+    })
     : new Configuration({
-        apiKey: API_KEY,
-        organization: ORGANIZATION,
-      });
-  const openai = new OpenAIApi(config);
+      apiKey: API_KEY,
+      organization: ORGANIZATION,
+    })
+  const openai = new OpenAIApi(config)
 
   const res = await openai.createChatCompletion({
     model: modelSelector(),
     max_tokens: OPENAI_MAX_TOKENS,
     stream: true,
     messages,
-  });
+  })
 
-  return OpenAIStream(res).pipeThrough(new TextDecoderStream());
+  return OpenAIStream(res).pipeThrough(new TextDecoderStream())
 }
 
 export function getOpenAiClient(): Client {
   if (API_KEY == null) {
-    throw new Error("OPENAI_API_KEY is not set");
+    throw new Error("OPENAI_API_KEY is not set")
   }
 
   return {
     completions,
-  };
+  }
 }

--- a/denops/ai-review/openai/client.ts
+++ b/denops/ai-review/openai/client.ts
@@ -1,39 +1,60 @@
-import { OPENAI_MAX_TOKENS } from "../constant.ts"
-import { ChatCompletionRequestMessage, Configuration, OpenAIApi, OpenAIStream } from "../deps/ai.ts"
-import { modelSelector } from "../store/config.ts"
+import { OPENAI_MAX_TOKENS } from "../constant.ts";
+import {
+  ChatCompletionRequestMessage,
+  Configuration,
+  OpenAIApi,
+  OpenAIStream,
+} from "../deps/ai.ts";
+import { azureConfigSelector, modelSelector } from "../store/config.ts";
 
-const ORGANIZATION = Deno.env.get("OPENAI_ORGANIZATION") ?? ""
-const API_KEY = Deno.env.get("OPENAI_API_KEY")
+const ORGANIZATION = Deno.env.get("OPENAI_ORGANIZATION") ?? "";
+const API_KEY = Deno.env.get("OPENAI_API_KEY");
 
 type Client = {
-  completions: typeof completions
-}
+  completions: typeof completions;
+};
 
-async function completions(
-  { messages }: { messages: Array<ChatCompletionRequestMessage> },
-): Promise<ReadableStream<string>> {
-  const config = new Configuration({
-    apiKey: API_KEY,
-    organization: ORGANIZATION,
-  })
-  const openai = new OpenAIApi(config)
+async function completions({
+  messages,
+}: {
+  messages: Array<ChatCompletionRequestMessage>;
+}): Promise<ReadableStream<string>> {
+  const azureConfig = azureConfigSelector();
+  const config: Configuration = azureConfig.use
+    ? new Configuration({
+        apiKey: API_KEY,
+        baseOptions: {
+          headers: {
+            "api-key": API_KEY,
+          },
+        },
+        basePath: azureConfig.url,
+        defaultQueryParams: new URLSearchParams({
+          "api-version": azureConfig.api_version,
+        }),
+      })
+    : new Configuration({
+        apiKey: API_KEY,
+        organization: ORGANIZATION,
+      });
+  const openai = new OpenAIApi(config);
 
   const res = await openai.createChatCompletion({
     model: modelSelector(),
     max_tokens: OPENAI_MAX_TOKENS,
     stream: true,
     messages,
-  })
+  });
 
-  return OpenAIStream(res).pipeThrough(new TextDecoderStream())
+  return OpenAIStream(res).pipeThrough(new TextDecoderStream());
 }
 
 export function getOpenAiClient(): Client {
   if (API_KEY == null) {
-    throw new Error("OPENAI_API_KEY is not set")
+    throw new Error("OPENAI_API_KEY is not set");
   }
 
   return {
     completions,
-  }
+  };
 }

--- a/denops/ai-review/store/config.ts
+++ b/denops/ai-review/store/config.ts
@@ -53,7 +53,6 @@ const validate = (config: Config) => {
   }
   const azureConfig = config.chat_gpt.azure
   if (azureConfig.use) {
-    console.log(azureConfig)
     if (azureConfig.url === "") {
       throw new Error("chatGPT azure.url is empty")
     }

--- a/denops/ai-review/store/config.ts
+++ b/denops/ai-review/store/config.ts
@@ -40,11 +40,28 @@ export const configSlice = createSlice({
   initialState: configInitialState,
   reducers: {
     config: (state, action: PayloadAction<ConfigState>) => {
-      // TODO: validate config
-      state.config = action.payload.config;
+      const input = action.payload.config;
+      validate(input);
+      state.config = input;
     },
   },
 });
+
+const validate = (config: Config) => {
+  if (config.chat_gpt.model === "") {
+    throw new Error("chatGPT model is empty");
+  }
+  const azureConfig = config.chat_gpt.azure;
+  if (azureConfig.use) {
+    console.log(azureConfig);
+    if (azureConfig.url === "") {
+      throw new Error("chatGPT azure.url is empty");
+    }
+    if (azureConfig.api_version === "") {
+      throw new Error("chatGPT azure.api_version is empty");
+    }
+  }
+};
 
 export const modelSelector = (): string =>
   store.getState().config.config.chat_gpt.model;

--- a/denops/ai-review/store/config.ts
+++ b/denops/ai-review/store/config.ts
@@ -1,25 +1,25 @@
-import { PayloadAction, redux } from "../deps/store.ts";
-import { store } from "./index.ts";
-const { createSlice } = redux;
+import { PayloadAction, redux } from "../deps/store.ts"
+import { store } from "./index.ts"
+const { createSlice } = redux
 
 export type Config = {
-  log_dir: string;
+  log_dir: string
   chat_gpt: {
-    model: string;
-    azure: AzureConfig;
+    model: string
+    azure: AzureConfig
     // Not use TypeScript
     // requests: Array
-  };
-};
+  }
+}
 type AzureConfig = {
-  use: boolean;
-  url: string;
-  api_version: string;
-};
+  use: boolean
+  url: string
+  api_version: string
+}
 
 type ConfigState = {
-  config: Config;
-};
+  config: Config
+}
 
 const configInitialState: ConfigState = {
   config: {
@@ -33,39 +33,39 @@ const configInitialState: ConfigState = {
       },
     },
   },
-};
+}
 
 export const configSlice = createSlice({
   name: "config",
   initialState: configInitialState,
   reducers: {
     config: (state, action: PayloadAction<ConfigState>) => {
-      const input = action.payload.config;
-      validate(input);
-      state.config = input;
+      const input = action.payload.config
+      validate(input)
+      state.config = input
     },
   },
-});
+})
 
 const validate = (config: Config) => {
   if (config.chat_gpt.model === "") {
-    throw new Error("chatGPT model is empty");
+    throw new Error("chatGPT model is empty")
   }
-  const azureConfig = config.chat_gpt.azure;
+  const azureConfig = config.chat_gpt.azure
   if (azureConfig.use) {
-    console.log(azureConfig);
+    console.log(azureConfig)
     if (azureConfig.url === "") {
-      throw new Error("chatGPT azure.url is empty");
+      throw new Error("chatGPT azure.url is empty")
     }
     if (azureConfig.api_version === "") {
-      throw new Error("chatGPT azure.api_version is empty");
+      throw new Error("chatGPT azure.api_version is empty")
     }
   }
-};
+}
 
 export const modelSelector = (): string =>
-  store.getState().config.config.chat_gpt.model;
+  store.getState().config.config.chat_gpt.model
 export const azureConfigSelector = (): AzureConfig =>
-  store.getState().config.config.chat_gpt.azure;
+  store.getState().config.config.chat_gpt.azure
 export const logDirSelector = (): string =>
-  store.getState().config.config.log_dir;
+  store.getState().config.config.log_dir

--- a/denops/ai-review/store/config.ts
+++ b/denops/ai-review/store/config.ts
@@ -1,28 +1,39 @@
-import { PayloadAction, redux } from "../deps/store.ts"
-import { store } from "./index.ts"
-const { createSlice } = redux
+import { PayloadAction, redux } from "../deps/store.ts";
+import { store } from "./index.ts";
+const { createSlice } = redux;
 
 export type Config = {
-  log_dir: string
+  log_dir: string;
   chat_gpt: {
-    model: string
+    model: string;
+    azure: AzureConfig;
     // Not use TypeScript
     // requests: Array
-  }
-}
+  };
+};
+type AzureConfig = {
+  use: boolean;
+  url: string;
+  api_version: string;
+};
 
 type ConfigState = {
-  config: Config
-}
+  config: Config;
+};
 
 const configInitialState: ConfigState = {
   config: {
     log_dir: "",
     chat_gpt: {
       model: "",
+      azure: {
+        use: false,
+        url: "",
+        api_version: "",
+      },
     },
   },
-}
+};
 
 export const configSlice = createSlice({
   name: "config",
@@ -30,10 +41,14 @@ export const configSlice = createSlice({
   reducers: {
     config: (state, action: PayloadAction<ConfigState>) => {
       // TODO: validate config
-      state.config = action.payload.config
+      state.config = action.payload.config;
     },
   },
-})
+});
 
-export const modelSelector = (): string => store.getState().config.config.chat_gpt.model
-export const logDirSelector = (): string => store.getState().config.config.log_dir
+export const modelSelector = (): string =>
+  store.getState().config.config.chat_gpt.model;
+export const azureConfigSelector = (): AzureConfig =>
+  store.getState().config.config.chat_gpt.azure;
+export const logDirSelector = (): string =>
+  store.getState().config.config.log_dir;


### PR DESCRIPTION
The following parameters were added to accommodate Azure:

* `chat_gpt.azure.use`  default is false, if true, you can use Azure settings, but you have to set the following parameters
* `chat_gpt.azure.url` Azure endpoint, url of the form `https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME`
* chat_gpt.azure.api_version` Azure OpenAI API version 

For more information on AzureAPI, please see https://learn.microsoft.com/ja-jp/azure/ai-services/openai/reference


And added some validation logics.